### PR TITLE
Fix spelling of SQLite

### DIFF
--- a/home/index.html
+++ b/home/index.html
@@ -102,7 +102,7 @@
                 <h2>Advanced Data Processing Libraries</h2>
             </div>
             <p>
-            Zorba users have immediate access to advanced, out of the box, data processing libraries. Built-in functions empower queries to use advanced math processing, string matching, data cleaning, or full-text features. Beyond that, conversion (e.g. CSV, PDF, HTML, ZIP), communication (e.g. HTTP, SMTP, IMAP), and connector (e.g. SQLLite, JDBC, CouchBase) libraries allow the user to productively process the Web's data.
+            Zorba users have immediate access to advanced, out of the box, data processing libraries. Built-in functions empower queries to use advanced math processing, string matching, data cleaning, or full-text features. Beyond that, conversion (e.g. CSV, PDF, HTML, ZIP), communication (e.g. HTTP, SMTP, IMAP), and connector (e.g. SQLite, JDBC, CouchBase) libraries allow the user to productively process the Web's data.
             </p>        
         </div>
         <div class="col-sm-6">


### PR DESCRIPTION
SQLite doesn't have 2 'L's. Saw the error while browsing your site, figured I might as well submit a patch. No big deal though.